### PR TITLE
chore: improve wiring for app v1

### DIFF
--- a/x/forwarding/keeper/keeper.go
+++ b/x/forwarding/keeper/keeper.go
@@ -43,6 +43,8 @@ func NewKeeper(
 	transientService store.TransientStoreService,
 	authKeeper types.AccountKeeper,
 	bankKeeper types.BankKeeper,
+	channelKeeper types.ChannelKeeper,
+	transferKeeper types.TransferKeeper,
 ) *Keeper {
 	builder := collections.NewSchemaBuilder(storeService)
 	transientBuilder := collections.NewSchemaBuilderFromAccessor(transientService.OpenTransientStore)
@@ -59,8 +61,10 @@ func NewKeeper(
 
 		PendingForwards: collections.NewMap(transientBuilder, types.PendingForwardsPrefix, "pending_forwards", collections.StringKey, codec.CollValue[types.ForwardingAccount](cdc)),
 
-		authKeeper: authKeeper,
-		bankKeeper: bankKeeper,
+		authKeeper:     authKeeper,
+		bankKeeper:     bankKeeper,
+		channelKeeper:  channelKeeper,
+		transferKeeper: transferKeeper,
 	}
 
 	schema, err := builder.Build()

--- a/x/forwarding/module.go
+++ b/x/forwarding/module.go
@@ -194,6 +194,8 @@ func ProvideModule(in ModuleInputs) ModuleOutputs {
 		in.TransientService,
 		in.AccountKeeper,
 		in.BankKeeper,
+		nil,
+		nil,
 	)
 	m := NewAppModule(k)
 


### PR DESCRIPTION
This is a small DX improvement, allows users of App v1 (instead of App v2, aka app wiring) to not have to call the `SetIBCKeepers` function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the initialization process to support additional channel and transfer management capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->