### PR TITLE
fix: return error in `SigVerificationDecorator` to avoid panic

### DIFF
--- a/.changelog/v2.0.3/bug-fixes/28-sigverification-ante.md
+++ b/.changelog/v2.0.3/bug-fixes/28-sigverification-ante.md
@@ -1,0 +1,1 @@
+- Return an error from the custom `SigVerificationDecorator` when forwarding account does not have balance to prevent a panic. ([#28](https://github.com/noble-assets/forwarding/pull/28))

--- a/.changelog/v2.0.3/summary.md
+++ b/.changelog/v2.0.3/summary.md
@@ -1,0 +1,3 @@
+May 9, 2025
+
+This is a non-consensus breaking patch to the v9 Argentum release line.

--- a/ante.go
+++ b/ante.go
@@ -73,10 +73,14 @@ func (d SigVerificationDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulat
 		}
 
 		address := types.GenerateAddress(msg.Channel, msg.Recipient, msg.Fallback)
-		balance := d.bank.GetAllBalances(ctx, address)
 
-		if balance.IsZero() || msg.Signer != address.String() {
+		if msg.Signer != address.String() {
 			return d.underlying.AnteHandle(ctx, tx, simulate, next)
+		}
+
+		balance := d.bank.GetAllBalances(ctx, address)
+		if balance.IsZero() {
+			return ctx, types.ErrInvalidAccountBalance.Wrap("account must have balance")
 		}
 
 		return next(ctx, tx, simulate)

--- a/types/errors.go
+++ b/types/errors.go
@@ -23,6 +23,7 @@ package types
 import "cosmossdk.io/errors"
 
 var (
-	ErrInvalidAuthority = errors.Register(ModuleName, 1, "signer is not authority")
-	ErrInvalidDenoms    = errors.Register(ModuleName, 2, "invalid allowed denoms")
+	ErrInvalidAuthority      = errors.Register(ModuleName, 1, "signer is not authority")
+	ErrInvalidDenoms         = errors.Register(ModuleName, 2, "invalid allowed denoms")
+	ErrInvalidAccountBalance = errors.Register(ModuleName, 3, "invalid account balance")
 )


### PR DESCRIPTION
In the current ante implementation, if the account considered as signer is a Forwarding account, and it does not have a balance, a panic is triggered during signerless registration. This panic is recovered, so does not cause liveness issues, but can be quickly fixed.

The error returned is reported here to keep track of it in case it can be of any help in the future:

```sh
$ noble on v10 > nobled tx forwarding register-account-signerlessly channel-1 osmo1t9u9qw6w0wvaqpp0ck63stt2wsk2tn5de593y5 --fees 20000uusdc --chain-id grand-1
code: 111222
codespace: undefined
data: ""
events: []
gas_used: "0"
gas_wanted: "0"
height: "0"
info: ""
logs: []
raw_log: "recovered: PubKeyForwarding.VerifySignature should never be invoked\nstack:\ngoroutine
  95684769 [running]:\nruntime/debug.Stack()\n\t/home/ec2-user/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/runtime/debug/stack.go:26
  +0x5e\ngithub.com/cosmos/cosmos-sdk/baseapp.NewBaseApp.newDefaultRecoveryMiddleware.func5({0x35104e0,
  0x46b1620})\n\t/home/ec2-user/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.50.13/baseapp/recovery.go:74
  +0x25\ngithub.com/cosmos/cosmos-sdk/baseapp.NewBaseApp.newDefaultRecoveryMiddleware.newRecoveryMiddleware.func7({0x35104e0?,
  0x46b1620?})\n\t/home/ec2-user/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.50.13/baseapp/recovery.go:42
  +0x2d\ngithub.com/cosmos/cosmos-sdk/baseapp.processRecovery({0x35104e0, 0x46b1620},
  0x0?)\n\t/home/ec2-user/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.50.13/baseapp/recovery.go:31
  +0x2f\ngithub.com/cosmos/cosmos-sdk/baseapp.processRecovery({0x35104e0, 0x46b1620},
  0x0?)\n\t/home/ec2-user/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.50.13/baseapp/recovery.go:36
  +0x53\ngithub.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).runTx.func1()\n\t/home/ec2-user/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.50.13/baseapp/baseapp.go:842
  +0x12c\npanic({0x35104e0?, 0x46b1620?})\n\t/home/ec2-user/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/runtime/panic.go:787
  +0x132\ngithub.com/cosmos/cosmos-sdk/x/auth/ante.SetUpContextDecorator.AnteHandle.func1()\n\t/home/ec2-user/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.50.13/x/auth/ante/setup.go:65
  +0x1e7\npanic({0x35104e0?, 0x46b1620?})\n\t/home/ec2-user/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/runtime/panic.go:787
  +0x132\ngithub.com/noble-assets/forwarding/v2/types.(*ForwardingPubKey).VerifySignature(0xc0b7980270?,
  {0x2c?, 0xc001071503?, 0x7?}, {0x1fb75?, 0x0?, 0xc09062eff0?})\n\t/home/ec2-user/go/pkg/mod/github.com/noble-assets/forwarding/v2@v2.0.2/types/account.go:69
  +0x25\ngithub.com/cosmos/cosmos-sdk/x/auth/signing.VerifySignature({0x4707ea0, 0xc09a072008},
  {0x471a0c8, 0xc099c1fef0}, {{0xc0b7980270, 0x2c}, {0xc001071503, 0x7}, 0x1fb75,
  0x0, ...}, ...)\n\t/home/ec2-user/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.50.13/x/auth/signing/verify.go:80
  +0x1c9\ngithub.com/cosmos/cosmos-sdk/x/auth/ante.SigVerificationDecorator.AnteHandle({{_,
  _}, _}, {{0x4707e30, 0x6cdcd60}, {0x4728b60, 0xc09a003540}, {{0x0, 0x0}, {0xc001071503,
  ...}, ...}, ...}, ...)\n\t/home/ec2-user/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.50.13/x/auth/ante/sigverify.go:323
  +0xd39\ngithub.com/noble-assets/forwarding/v2.SigVerificationDecorator.AnteHandle({{_,
  _}, {_, _}}, {{0x4707e30, 0x6cdcd60}, {0x4728b60, 0xc09a003540}, {{0x0, 0x0}, ...},
  ...}, ...)\n\t/home/ec2-user/go/pkg/mod/github.com/noble-assets/forwarding/v2@v2.0.2/ante.go:79
  +0x69e\nautocctp%2edev.SigVerificationDecorator.AnteHandle({{_, _}, {_, _}, {_,
  _}}, {{0x4707e30, 0x6cdcd60}, {0x4728b60, 0xc09a003540}, ...}, ...)\n\t/home/ec2-user/go/pkg/mod/autocctp.dev@v1.0.0-beta.0/ante.go:82
  +0x695\ngithub.com/noble-assets/noble/v10.NewAnteHandler.ChainAnteDecorators.func2({{0x4707e30,
  0x6cdcd60}, {0x4728b60, 0xc09a003540}, {{0x0, 0x0}, {0xc001071503, 0x7}, 0x1c4b1be,
  {0x12773009, ...}, ...}, ...}, ...)\n\t/home/ec2-user/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.50.13/types/handler.go:48
  +0x105\ngithub.com/cosmos/cosmos-sdk/x/auth/ante.SigGasConsumeDecorator.AnteHandle({{_,
  _}, _}, {{0x4707e30, 0x6cdcd60}, {0x4728b60, 0xc09a003540}, {{0x0, 0x0}, {0xc001071503,
  ...}, ...}, ...}, ...)\n\t/home/ec2-user/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.50.13/x/auth/ante/sigverify.go:212
  +0x76e\ngithub.com/noble-assets/noble/v10.NewAnteHandler.ChainAnteDecorators.func2({{0x4707e30,
  0x6cdcd60}, {0x4728b60, 0xc09a003540}, {{0x0, 0x0}, {0xc001071503, 0x7}, 0x1c4b1be,
  {0x12773009, ...}, ...}, ...}, ...)\n\t/home/ec2-user/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.50.13/types/handler.go:48
  +0x105\ngithub.com/cosmos/cosmos-sdk/x/auth/ante.ValidateSigCountDecorator.AnteHandle({{_,
  _}}, {{0x4707e30, 0x6cdcd60}, {0x4728b60, 0xc09a003540}, {{0x0, 0x0}, {0xc001071503,
  0x7}, ...}, ...}, ...)\n\t/home/ec2-user/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.50.13/x/auth/ante/sigverify.go:420
  +0x4ae\ngithub.com/noble-assets/noble/v10.NewAnteHandler.ChainAnteDecorators.func2({{0x4707e30,
  0x6cdcd60}, {0x4728b60, 0xc09a003540}, {{0x0, 0x0}, {0xc001071503, 0x7}, 0x1c4b1be,
  {0x12773009, ...}, ...}, ...}, ...)\n\t/home/ec2-user/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.50.13/types/handler.go:48
  +0x105\ngithub.com/cosmos/cosmos-sdk/x/auth/ante.SetPubKeyDecorator.AnteHandle({{_,
  _}}, {{0x4707e30, 0x6cdcd60}, {0x4728b60, 0xc09a003540}, {{0x0, 0x0}, {0xc001071503,
  0x7}, ...}, ...}, ...)\n\t/home/ec2-user/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.50.13/x/auth/ante/sigverify.go:141
  +0xd12\ngithub.com/noble-assets/noble/v10.NewAnteHandler.ChainAnteDecorators.func2({{0x4707e30,
  0x6cdcd60}, {0x4728b60, 0xc09a003540}, {{0x0, 0x0}, {0xc001071503, 0x7}, 0x1c4b1be,
  {0x12773009, ...}, ...}, ...}, ...)\n\t/home/ec2-user/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.50.13/types/handler.go:48
  +0x105\ngithub.com/cosmos/cosmos-sdk/x/auth/ante.DeductFeeDecorator.AnteHandle({{_,
  _}, {_, _}, {_, _}, _}, {{0x4707e30, 0x6cdcd60}, {0x4728b60, ...}, ...}, ...)\n\t/home/ec2-user/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.50.13/x/auth/ante/fee.go:70
  +0x3f0\ngithub.com/noble-assets/noble/v10.NewAnteHandler.ChainAnteDecorators.func2({{0x4707e30,
  0x6cdcd60}, {0x4728b60, 0xc09a003540}, {{0x0, 0x0}, {0xc001071503, 0x7}, 0x1c4b1be,
  {0x12773009, ...}, ...}, ...}, ...)\n\t/home/ec2-user/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.50.13/types/handler.go:48
  +0x105\ngithub.com/cosmos/cosmos-sdk/x/auth/ante.ConsumeTxSizeGasDecorator.AnteHandle({{_,
  _}}, {{0x4707e30, 0x6cdcd60}, {0x4728b60, 0xc09a003540}, {{0x0, 0x0}, {0xc001071503,
  0x7}, ...}, ...}, ...)\n\t/home/ec2-user/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.50.13/x/auth/ante/basic.go:153
  +0x6e6\ngithub.com/noble-assets/noble/v10.NewAnteHandler.ChainAnteDecorators.func2({{0x4707e30,
  0x6cdcd60}, {0x4728b60, 0xc09a003540}, {{0x0, 0x0}, {0xc001071503, 0x7}, 0x1c4b1be,
  {0x12773009, ...}, ...}, ...}, ...)\n\t/home/ec2-user/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.50.13/types/handler.go:48
  +0x105\ngithub.com/noble-assets/noble/v10.PermissionedHyperlaneDecorator.AnteHandle({},
  {{0x4707e30, 0x6cdcd60}, {0x4728b60, 0xc09a003540}, {{0x0, 0x0}, {0xc001071503,
  0x7}, 0x1c4b1be, ...}, ...}, ...)\n\t/home/ec2-user/noble/ante_permissioned_hyperlane.go:50
  +0x156\ngithub.com/noble-assets/noble/v10.NewAnteHandler.ChainAnteDecorators.func2({{0x4707e30,
  0x6cdcd60}, {0x4728b60, 0xc09a003540}, {{0x0, 0x0}, {0xc001071503, 0x7}, 0x1c4b1be,
  {0x12773009, ...}, ...}, ...}, ...)\n\t/home/ec2-user/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.50.13/types/handler.go:48
  +0x105\ngithub.com/circlefin/noble-fiattokenfactory/x/fiattokenfactory.IsBlacklistedDecorator.AnteHandle({_},
  {{0x4707e30, 0x6cdcd60}, {0x4728b60, 0xc09a003540}, {{0x0, 0x0}, {0xc001071503,
  0x7}, 0x1c4b1be, ...}, ...}, ...)\n\t/home/ec2-user/go/pkg/mod/github.com/circlefin/noble-fiattokenfactory@v0.0.0-20250123235012-5f9bd9dd2c5b/x/fiattokenfactory/ante.go:120
  +0x291\ngithub.com/noble-assets/noble/v10.NewAnteHandler.ChainAnteDecorators.func2({{0x4707e30,
  0x6cdcd60}, {0x4728b60, 0xc09a003540}, {{0x0, 0x0}, {0xc001071503, 0x7}, 0x1c4b1be,
  {0x12773009, ...}, ...}, ...}, ...)\n\t/home/ec2-user/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.50.13/types/handler.go:48
  +0x105\ngithub.com/circlefin/noble-fiattokenfactory/x/fiattokenfactory.IsPausedDecorator.AnteHandle({{_,
  _}, _}, {{0x4707e30, 0x6cdcd60}, {0x4728b60, 0xc09a003540}, {{0x0, 0x0}, {0xc001071503,
  ...}, ...}, ...}, ...)\n\t/home/ec2-user/go/pkg/mod/github.com/circlefin/noble-fiattokenfactory@v0.0.0-20250123235012-5f9bd9dd2c5b/x/fiattokenfactory/ante.go:53
  +0x20e\ngithub.com/noble-assets/noble/v10.NewAnteHandler.ChainAnteDecorators.func2({{0x4707e30,
  0x6cdcd60}, {0x4728b60, 0xc09a003540}, {{0x0, 0x0}, {0xc001071503, 0x7}, 0x1c4b1be,
  {0x12773009, ...}, ...}, ...}, ...)\n\t/home/ec2-user/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.50.13/types/handler.go:48
  +0x105\ngithub.com/cosmos/cosmos-sdk/x/auth/ante.ValidateMemoDecorator.AnteHandle({{_,
  _}}, {{0x4707e30, 0x6cdcd60}, {0x4728b60, 0xc09a003540}, {{0x0, 0x0}, {0xc001071503,
  0x7}, ...}, ...}, ...)\n\t/home/ec2-user/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.50.13/x/auth/ante/basic.go:72
  +0x20e\ngithub.com/noble-assets/noble/v10.NewAnteHandler.ChainAnteDecorators.func2({{0x4707e30,
  0x6cdcd60}, {0x4728b60, 0xc09a003540}, {{0x0, 0x0}, {0xc001071503, 0x7}, 0x1c4b1be,
  {0x12773009, ...}, ...}, ...}, ...)\n\t/home/ec2-user/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.50.13/types/handler.go:48
  +0x105\ngithub.com/cosmos/cosmos-sdk/x/auth/ante.TxTimeoutHeightDecorator.AnteHandle({},
  {{0x4707e30, 0x6cdcd60}, {0x4728b60, 0xc09a003540}, {{0x0, 0x0}, {0xc001071503,
  0x7}, 0x1c4b1be, ...}, ...}, ...)\n\t/home/ec2-user/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.50.13/x/auth/ante/basic.go:216
  +0x2ee\ngithub.com/noble-assets/noble/v10.NewAnteHandler.ChainAnteDecorators.func2({{0x4707e30,
  0x6cdcd60}, {0x4728b60, 0xc09a003540}, {{0x0, 0x0}, {0xc001071503, 0x7}, 0x1c4b1be,
  {0x12773009, ...}, ...}, ...}, ...)\n\t/home/ec2-user/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.50.13/types/handler.go:48
  +0x105\ngithub.com/cosmos/cosmos-sdk/x/auth/ante.ValidateBasicDecorator.AnteHandle({},
  {{0x4707e30, 0x6cdcd60}, {0x4728b60, 0xc09a003540}, {{0x0, 0x0}, {0xc001071503,
  0x7}, 0x1c4b1be, ...}, ...}, ...)\n\t/home/ec2-user/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.50.13/x/auth/ante/basic.go:39
  +0x2b6\ngithub.com/noble-assets/noble/v10.NewAnteHandler.ChainAnteDecorators.func2({{0x4707e30,
  0x6cdcd60}, {0x4728b60, 0xc09a003540}, {{0x0, 0x0}, {0xc001071503, 0x7}, 0x1c4b1be,
  {0x12773009, ...}, ...}, ...}, ...)\n\t/home/ec2-user/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.50.13/types/handler.go:48
  +0x105\ngithub.com/cosmos/cosmos-sdk/x/auth/ante.RejectExtensionOptionsDecorator.AnteHandle({_},
  {{0x4707e30, 0x6cdcd60}, {0x4728b60, 0xc09a003540}, {{0x0, 0x0}, {0xc001071503,
  0x7}, 0x1c4b1be, ...}, ...}, ...)\n\t/home/ec2-user/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.50.13/x/auth/ante/ext.go:52
  +0x18e\ngithub.com/noble-assets/noble/v10.NewAnteHandler.ChainAnteDecorators.func2({{0x4707e30,
  0x6cdcd60}, {0x4728b60, 0xc09a003540}, {{0x0, 0x0}, {0xc001071503, 0x7}, 0x1c4b1be,
  {0x12773009, ...}, ...}, ...}, ...)\n\t/home/ec2-user/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.50.13/types/handler.go:48
  +0x105\ngithub.com/cosmos/cosmos-sdk/x/auth/ante.SetUpContextDecorator.AnteHandle({},
  {{0x4707e30, 0x6cdcd60}, {0x4728b60, 0xc09a003540}, {{0x0, 0x0}, {0xc001071503,
  0x7}, 0x1c4b1be, ...}, ...}, ...)\n\t/home/ec2-user/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.50.13/x/auth/ante/setup.go:70
  +0x7c6\ngithub.com/noble-assets/noble/v10.NewAnteHandler.ChainAnteDecorators.func2({{0x4707e30,
  0x6cdcd60}, {0x4728b60, 0xc09a003540}, {{0x0, 0x0}, {0xc001071503, 0x7}, 0x1c4b1be,
  {0x12773009, ...}, ...}, ...}, ...)\n\t/home/ec2-user/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.50.13/types/handler.go:48
  +0x105\ngithub.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).runTx(0xc00114dd48, 0x0,
  {0xc096cc1400, 0xfa, 0xfc})\n\t/home/ec2-user/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.50.13/baseapp/baseapp.go:905
  +0x93c\ngithub.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).CheckTx(0xc00114dd48, 0x0?)\n\t/home/ec2-user/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.50.13/baseapp/abci.go:350
  +0x4d\ngithub.com/cosmos/cosmos-sdk/server.cometABCIWrapper.CheckTx(...)\n\t/home/ec2-user/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.50.13/server/cmt_abci.go:28\ngithub.com/cometbft/cometbft/abci/client.(*localClient).CheckTxAsync(0xc00319cfc0,
  {0x4708108?, 0x6cdcd60?}, 0xc014b186c0)\n\t/home/ec2-user/go/pkg/mod/github.com/cometbft/cometbft@v0.38.17/abci/client/local_client.go:51
  +0xd9\ngithub.com/cometbft/cometbft/proxy.(*appConnMempool).CheckTxAsync(0xc00326df68,
  {0x4708108, 0x6cdcd60}, 0xc014b186c0)\n\t/home/ec2-user/go/pkg/mod/github.com/cometbft/cometbft@v0.38.17/proxy/app_conn.go:147
  +0x157\ngithub.com/cometbft/cometbft/mempool.(*CListMempool).CheckTx(0xc0011e2b60,
  {0xc096cc1400, 0xfa, 0xfc}, 0xc0996c2768, {0x0?, {0x0?, 0xc02efd9340?}})\n\t/home/ec2-user/go/pkg/mod/github.com/cometbft/cometbft@v0.38.17/mempool/clist_mempool.go:271
  +0x335\ngithub.com/cometbft/cometbft/rpc/core.(*Environment).BroadcastTxSync(0xc001fd8908,
  0xc014b186a0, {0xc096cc1400, 0xfa, 0xfc})\n\t/home/ec2-user/go/pkg/mod/github.com/cometbft/cometbft@v0.38.17/rpc/core/mempool.go:35
  +0xec\nreflect.Value.call({0x3654ca0?, 0xc0018058c0?, 0x3cb8080?}, {0x3cc6dd4, 0x4},
  {0xc07bb4e120, 0x2, 0x2?})\n\t/home/ec2-user/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/reflect/value.go:581
  +0xca6\nreflect.Value.Call({0x3654ca0?, 0xc0018058c0?, 0x159?}, {0xc07bb4e120?,
  0x3cb8080?, 0xc0278ab538?})\n\t/home/ec2-user/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/reflect/value.go:365
  +0xb9\ngithub.com/cometbft/cometbft/rpc/jsonrpc/server.RegisterRPCFuncs.makeJSONRPCHandler.func3({0x46efec0,
  0xc0996c26d8}, 0xc09759ec80)\n\t/home/ec2-user/go/pkg/mod/github.com/cometbft/cometbft@v0.38.17/rpc/jsonrpc/server/http_json_handler.go:108
  +0xcb0\ngithub.com/cometbft/cometbft/rpc/jsonrpc/server.RegisterRPCFuncs.handleInvalidJSONRPCPaths.func4({0x46efec0?,
  0xc0996c26d8?}, 0xc0984e9b80?)\n\t/home/ec2-user/go/pkg/mod/github.com/cometbft/cometbft@v0.38.17/rpc/jsonrpc/server/http_json_handler.go:140
  +0x42\nnet/http.HandlerFunc.ServeHTTP(0xc000a34780?, {0x46efec0?, 0xc0996c26d8?},
  0x3cd74e3?)\n\t/home/ec2-user/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/net/http/server.go:2294
  +0x29\nnet/http.(*ServeMux).ServeHTTP(0xc003303380?, {0x46efec0, 0xc0996c26d8},
  0xc09759ec80)\n\t/home/ec2-user/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/net/http/server.go:2822
  +0x1c4\ngithub.com/cometbft/cometbft/node.(*Node).startRPC.(*Cors).Handler.func9({0x46efec0,
  0xc0996c26d8}, 0xc09759ec80)\n\t/home/ec2-user/go/pkg/mod/github.com/rs/cors@v1.11.1/cors.go:289
  +0x184\nnet/http.HandlerFunc.ServeHTTP(0xd?, {0x46efec0?, 0xc0996c26d8?}, 0x3cd74e3?)\n\t/home/ec2-user/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/net/http/server.go:2294
  +0x29\ngithub.com/cometbft/cometbft/rpc/jsonrpc/server.defaultHandler.ServeHTTP(...)\n\t/home/ec2-user/go/pkg/mod/github.com/cometbft/cometbft@v0.38.17/rpc/jsonrpc/server/http_server.go:259\ngithub.com/cometbft/cometbft/rpc/jsonrpc/server.Serve.RecoverAndLogHandler.func1({0x46e6780,
  0xc08cdcb260}, 0xc09759ec80)\n\t/home/ec2-user/go/pkg/mod/github.com/cometbft/cometbft@v0.38.17/rpc/jsonrpc/server/http_server.go:234
  +0x233\nnet/http.HandlerFunc.ServeHTTP(0x46bbae0?, {0x46e6780?, 0xc08cdcb260?},
  0x34df3e0?)\n\t/home/ec2-user/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/net/http/server.go:2294
  +0x29\ngithub.com/cometbft/cometbft/rpc/jsonrpc/server.Serve.PreChecksHandler.func2({0x46e6780,
  0xc08cdcb260}, 0xc09759ec80)\n\t/home/ec2-user/go/pkg/mod/github.com/cometbft/cometbft@v0.38.17/rpc/jsonrpc/server/http_server.go:327
  +0x108\nnet/http.HandlerFunc.ServeHTTP(0x41d6e5?, {0x46e6780?, 0xc08cdcb260?}, 0xc08cdcb201?)\n\t/home/ec2-user/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/net/http/server.go:2294
  +0x29\nnet/http.serverHandler.ServeHTTP({0x46d34b0?}, {0x46e6780?, 0xc08cdcb260?},
  0x6?)\n\t/home/ec2-user/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/net/http/server.go:3301
  +0x8e\nnet/http.(*conn).serve(0xc07493b170, {0x4708028, 0xc003262c00})\n\t/home/ec2-user/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/net/http/server.go:2102
  +0x625\ncreated by net/http.(*Server).Serve in goroutine 154\n\t/home/ec2-user/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/net/http/server.go:3454
  +0x485\n: panic"
timestamp: ""
tx: null
txhash: 9B357E340D2B6FE7EEAEFE3F2C09C48527B94FE7630DDB55A7C2E5A76ACE067D

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved validation when processing transactions by explicitly returning an error if an account has a zero balance, preventing execution panics.
- **New Features**
	- Added a new error message for invalid account balances to provide clearer feedback during transaction processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->